### PR TITLE
ADA-13 | Input validation for modals

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>AllDone ToDo List App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/components/Tasks/AddTaskModal.css
+++ b/frontend/src/components/Tasks/AddTaskModal.css
@@ -8,19 +8,37 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  backdrop-filter: blur(5px);
 }
 
 .modal {
-  background: white;
+  background: #fff;
   padding: 20px;
   max-width: 500px;
   width: 100%;
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  animation: slide-in 0.3s ease-out;
+  position: relative;
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 .modal h2 {
   margin-top: 0;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+  color: #333;
 }
 
 .modal form {
@@ -29,20 +47,23 @@
 }
 
 .modal form input {
-  padding: 8px;
+  padding: 12px;
   margin-bottom: 10px;
   border: 1px solid #ddd;
-  border-radius: 4px;
+  border-radius: 8px;
+  font-size: 16px;
 }
 
 .modal form button {
-  padding: 8px 16px;
+  padding: 12px 16px;
   border: none;
   background-color: #007bff;
   color: white;
-  border-radius: 4px;
+  border-radius: 8px;
   cursor: pointer;
-  margin-right: 10px;
+  font-size: 16px;
+  transition: background-color 0.2s;
+  margin-top: 10px;
 }
 
 .modal form button[type="button"] {
@@ -55,4 +76,11 @@
 
 .modal form button[type="button"]:hover {
   background-color: #5a6268;
+}
+
+.error-message {
+  color: red;
+  font-size: 14px;
+  margin-bottom: 10px;
+  text-align: center;
 }

--- a/frontend/src/components/Tasks/AddTaskModal.js
+++ b/frontend/src/components/Tasks/AddTaskModal.js
@@ -7,14 +7,22 @@ Modal.setAppElement('#root');
 
 const AddTaskModal = ({ isOpen, onRequestClose, onAddTask }) => {
   const [taskName, setTaskName] = useState('');
+  const [error, setError] = useState('');
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (taskName.trim()) {
-      onAddTask(taskName);
-      setTaskName('');
-      onRequestClose();
+    if (taskName.trim() === '') {
+      setError('Task name cannot be empty.');
+      return;
     }
+    if (taskName.length > 100) {
+      setError('Task name cannot exceed 100 characters.');
+      return;
+    }
+    onAddTask(taskName);
+    setTaskName('');
+    setError('');
+    onRequestClose();
   };
 
   return (
@@ -26,15 +34,17 @@ const AddTaskModal = ({ isOpen, onRequestClose, onAddTask }) => {
       overlayClassName="overlay"
     >
       <h2>Add Task</h2>
+      {error && <div className="error-message" data-testid="error-message">{error}</div>}
       <form onSubmit={handleSubmit}>
         <input
           type="text"
           placeholder="Enter Task"
           value={taskName}
           onChange={(e) => setTaskName(e.target.value)}
+          data-testid="task-input"
         />
         <button type="submit" data-testid="modal-add-task-button">Add Task</button>
-        <button type="button" onClick={onRequestClose}>Cancel</button>
+        <button type="button" onClick={onRequestClose} data-testid="modal-cancel-button">Cancel</button>
       </form>
     </Modal>
   );

--- a/frontend/src/components/Tasks/EditTaskModal.js
+++ b/frontend/src/components/Tasks/EditTaskModal.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Modal from 'react-modal';
 import PropTypes from 'prop-types';
-import './EditTaskModal.css';
+import './AddTaskModal.css';
 
 Modal.setAppElement('#root');
 
@@ -24,6 +24,7 @@ const EditTaskModal = ({ isOpen, onRequestClose, onEditTask, task }) => {
       return;
     }
     onEditTask(task.id, taskName);
+    setError('');
     onRequestClose();
   };
 
@@ -35,18 +36,18 @@ const EditTaskModal = ({ isOpen, onRequestClose, onEditTask, task }) => {
       className="modal"
       overlayClassName="overlay"
     >
-      <button className="close-button" onClick={onRequestClose}>&times;</button>
       <h2>Edit Task</h2>
-      {error && <div data-testid="error-message" className="error-message">{error}</div>}
+      {error && <div className="error-message" data-testid="error-message">{error}</div>}
       <form onSubmit={handleSubmit}>
         <input
           type="text"
           placeholder="Enter Updated Task"
           value={taskName}
           onChange={(e) => setTaskName(e.target.value)}
+          data-testid="task-input"
         />
         <button type="submit" data-testid="modal-edit-task-button">Edit Task</button>
-        <button type="button" onClick={onRequestClose} data-testid="modal-cancel-button">Cancel</button>
+        <button type="button" onClick={onRequestClose} data-testid="edit-modal-cancel-button">Cancel</button>
       </form>
     </Modal>
   );

--- a/frontend/src/components/Tasks/tests/AddTaskModal.test.js
+++ b/frontend/src/components/Tasks/tests/AddTaskModal.test.js
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import axios from 'axios';
 import Tasks from '../Tasks';
+import AddTaskModal from '../AddTaskModal';
 
 jest.mock('axios');
 
@@ -10,22 +11,61 @@ beforeAll(() => {
   process.env.REACT_APP_API_URL = 'http://localhost:5000';
 });
 
+const renderAddTaskModal = (props) => {
+  render(<AddTaskModal {...props} />);
+};
+
+const changeTaskNameAndSubmit = (taskName) => {
+  fireEvent.change(screen.getByPlaceholderText('Enter Task'), { target: { value: taskName } });
+  fireEvent.click(screen.getByTestId('modal-add-task-button'));
+};
+
+// parameterized tests for invalid task names
+test.each([
+  ['', 'Task name cannot be empty.'],
+  ['   ', 'Task name cannot be empty.'],
+  ['a'.repeat(101), 'Task name cannot exceed 100 characters.']
+])('shows error when the task name is "%s"', async (taskName, expectedError) => {
+  const onAddTask = jest.fn();
+  const onRequestClose = jest.fn();
+
+  renderAddTaskModal({ isOpen: true, onAddTask, onRequestClose });
+
+  changeTaskNameAndSubmit(taskName);
+
+  await waitFor(() => {
+    expect(screen.getByTestId('error-message')).toHaveTextContent(expectedError);
+  });
+});
+
+// test for exactly 100 chars
+test('accepts a task name with exactly 100 characters', async () => {
+  const onAddTask = jest.fn();
+  const onRequestClose = jest.fn();
+
+  renderAddTaskModal({ isOpen: true, onAddTask, onRequestClose });
+
+  const taskName = 'a'.repeat(100);
+  changeTaskNameAndSubmit(taskName);
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('error-message')).not.toBeInTheDocument();
+    expect(onAddTask).toHaveBeenCalledWith(taskName);
+  });
+});
+
 test('adds a task when the Add Task button is clicked and the form is submitted', async () => {
   const newTask = { id: 3, name: 'New Task', checked: false };
 
   axios.get.mockResolvedValue({ data: { tasks: [] } });
-    axios.post.mockResolvedValue({ data: { task: newTask } });
+  axios.post.mockResolvedValue({ data: { task: newTask } });
 
   render(<Tasks />);
 
-  // Open the add task modal
   fireEvent.click(screen.getByTestId('open-add-task-modal-button'));
   fireEvent.change(screen.getByPlaceholderText('Enter Task'), { target: { value: 'New Task' } });
-
-  // Submit the form
   fireEvent.click(screen.getByTestId('modal-add-task-button'));
 
-  // Verify the new task is displayed
   await waitFor(() => {
     expect(screen.getByText('New Task')).toBeInTheDocument();
   });

--- a/frontend/src/components/Tasks/tests/EditTaskModal.test.js
+++ b/frontend/src/components/Tasks/tests/EditTaskModal.test.js
@@ -10,82 +10,84 @@ beforeAll(() => {
   process.env.REACT_APP_API_URL = 'http://localhost:5000';
 });
 
+const tasks = [
+  { id: 1, name: 'Test Task 1', checked: false },
+  { id: 2, name: 'Test Task 2', checked: true }
+];
+
+// helper functions for reusability
+const renderTasksComponent = async () => {
+  axios.get.mockResolvedValue({ data: { tasks } });
+  render(<Tasks />);
+  await screen.findByText('Test Task 1');
+};
+
+const openEditModalAndSubmit = (newTaskName) => {
+  fireEvent.click(screen.getByTestId('edit-button-1'));
+  fireEvent.change(screen.getByPlaceholderText('Enter Updated Task'), { target: { value: newTaskName } });
+  fireEvent.click(screen.getByTestId('modal-edit-task-button'));
+};
+
+const openEditModalAndCancel = (newTaskName) => {
+  fireEvent.click(screen.getByTestId('edit-button-1'));
+  fireEvent.change(screen.getByPlaceholderText('Enter Updated Task'), { target: { value: newTaskName } });
+  fireEvent.click(screen.getByTestId('edit-modal-cancel-button'));
+};
+
 test('edits a task when the Edit Task button is clicked and the form is submitted', async () => {
-  const tasks = [
-    { id: 1, name: 'Test Task 1', checked: false },
-    { id: 2, name: 'Test Task 2', checked: true }
-  ];
   const updatedTask = { ...tasks[0], name: 'Updated Task' };
 
-  axios.get.mockResolvedValue({ data: { tasks } });
   axios.put.mockResolvedValue({ data: { task: updatedTask } });
 
-  render(<Tasks />);
+  await renderTasksComponent();
 
-  expect(await screen.findByText('Test Task 1')).toBeInTheDocument();
-  fireEvent.click(screen.getByTestId('edit-button-1'));
-  fireEvent.change(screen.getByPlaceholderText('Enter Updated Task'), { target: { value: 'Updated Task' } });
-  fireEvent.click(screen.getByTestId('modal-edit-task-button'));
+  openEditModalAndSubmit('Updated Task');
 
   await waitFor(() => {
     expect(screen.getByText('Updated Task')).toBeInTheDocument();
   });
 });
 
-test('shows error when the task name is empty', async () => {
-  const tasks = [
-    { id: 1, name: 'Test Task 1', checked: false },
-    { id: 2, name: 'Test Task 2', checked: true }
-  ];
-
-  axios.get.mockResolvedValue({ data: { tasks } });
-
-  render(<Tasks />);
-
-  expect(await screen.findByText('Test Task 1')).toBeInTheDocument();
-  fireEvent.click(screen.getByTestId('edit-button-1'));
-  fireEvent.change(screen.getByPlaceholderText('Enter Updated Task'), { target: { value: '' } });
-  fireEvent.click(screen.getByTestId('modal-edit-task-button'));
-
-  await waitFor(() => {
-    expect(screen.getByTestId('error-message')).toHaveTextContent('Task name cannot be empty.');
+// paramaterised test to avoid repetiton
+test.each([
+    ['', 'Task name cannot be empty.'],
+    ['   ', 'Task name cannot be empty.'],
+    ['a'.repeat(101), 'Task name cannot exceed 100 characters.']
+  ])('shows error when the task name is "%s"', async (taskName, expectedError) => {
+    await renderTasksComponent();
+  
+    openEditModalAndSubmit(taskName);
+  
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent(expectedError);
+    });
   });
-});
 
-test('shows error when the task name exceeds 100 characters', async () => {
-  const tasks = [
-    { id: 1, name: 'Test Task 1', checked: false },
-    { id: 2, name: 'Test Task 2', checked: true }
-  ];
-
-  axios.get.mockResolvedValue({ data: { tasks } });
-
-  render(<Tasks />);
-
-  expect(await screen.findByText('Test Task 1')).toBeInTheDocument();
-  fireEvent.click(screen.getByTestId('edit-button-1'));
-  fireEvent.change(screen.getByPlaceholderText('Enter Updated Task'), { target: { value: 'a'.repeat(101) } });
-  fireEvent.click(screen.getByTestId('modal-edit-task-button'));
-
-  await waitFor(() => {
-    expect(screen.getByTestId('error-message')).toHaveTextContent('Task name cannot exceed 100 characters.');
+test('accepts a task name with exactly 100 characters', async () => {
+    const tasks = [
+      { id: 1, name: 'Test Task 1', checked: false },
+      { id: 2, name: 'Test Task 2', checked: true }
+    ];
+  
+    axios.get.mockResolvedValue({ data: { tasks } });
+    axios.put.mockResolvedValue({ data: { task: { ...tasks[0], name: 'a'.repeat(100) } } });
+  
+    render(<Tasks />);
+  
+    expect(await screen.findByText('Test Task 1')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('edit-button-1'));
+    fireEvent.change(screen.getByPlaceholderText('Enter Updated Task'), { target: { value: 'a'.repeat(100) } });
+    fireEvent.click(screen.getByTestId('modal-edit-task-button'));
+  
+    await waitFor(() => {
+      expect(screen.getByText('a'.repeat(100))).toBeInTheDocument();
+    });
   });
-});
 
 test('cancels the edit task action', async () => {
-  const tasks = [
-    { id: 1, name: 'Test Task 1', checked: false },
-    { id: 2, name: 'Test Task 2', checked: true }
-  ];
+  await renderTasksComponent();
 
-  axios.get.mockResolvedValue({ data: { tasks } });
-
-  render(<Tasks />);
-
-  expect(await screen.findByText('Test Task 1')).toBeInTheDocument();
-  fireEvent.click(screen.getByTestId('edit-button-1'));
-  fireEvent.change(screen.getByPlaceholderText('Enter Updated Task'), { target: { value: 'Updated Task' } });
-  fireEvent.click(screen.getByTestId('modal-cancel-button'));
+  openEditModalAndCancel('Updated Task');
 
   await waitFor(() => {
     expect(screen.queryByText('Updated Task')).not.toBeInTheDocument();


### PR DESCRIPTION
Also refactored test files for modals - created helper functions and reusable consts. Including paramaterised tests.

## Description

Added input validation for both AddTaskModal and EditTask Modal. Improved testing via refactoring and paramaterised tests.

## How Has This Been Tested?

- Manual Tests
- Unit tests

## Screenshots (If appropriate):

### Empty Task Error
![Empty Task Error](https://github.com/user-attachments/assets/9e9243f9-9e3d-43a5-be24-20483bdb799c)

### Task Name Too Long
![Task Name Too Long](https://github.com/user-attachments/assets/e7345092-33e8-4fb3-9673-55a3a972ff05)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
